### PR TITLE
feat: add dual-auth support (GITHUB_TOKEN + gh CLI) across all scripts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -193,7 +193,7 @@ Generates an HTML report of issues created in a date range (`MONTH_START`/`MONTH
 
 ### `github-organize-stars`
 
-Uses `gh` CLI GraphQL (not `curl`) to fetch all starred repos. Categorizes by primary language, GitHub topics, and name keywords using a `RULES` array (pipe-delimited: `List Name|LANGUAGES|TOPICS|NAME_KEYWORDS`; first matching rule wins). Caches stars at `~/.cache/gh-star-organizer/stars.json`. Supports `--dry-run`, `-y` (skip confirm), `--show-repos`, and `--no-cache`. Adds repos to Lists in batches of 25.
+Uses `gh` CLI GraphQL (not `curl`) to fetch all starred repos. Accepts `GITHUB_TOKEN` env var or an active `gh` auth session for authentication. Categorizes by primary language, GitHub topics, and name keywords using a `RULES` array (pipe-delimited: `List Name|LANGUAGES|TOPICS|NAME_KEYWORDS`; first matching rule wins). Caches stars at `~/.cache/gh-star-organizer/stars.json`. Supports `--dry-run`, `-y` (skip confirm), `--show-repos`, and `--no-cache`. Adds repos to Lists in batches of 25.
 
 ### `github-repo-from-template`
 
@@ -201,11 +201,11 @@ Creates a private repo from `TEMPLATE_REPO` (including all branches), assigns ad
 
 ### `github-repo-permissions-report`
 
-Uses `gh` CLI (not `curl`/`GITHUB_TOKEN`) for all API calls. Accepts `-r OWNER/REPO`, `-b BRANCH`, and `-o FILE` flags. Outputs a CSV with two record types: `permission` (all users/teams) and `bypass_actor` (explicit PR approval bypass entries). Reports both branch protection rules and repository rulesets. Requires `gh auth login` before running — no `GITHUB_TOKEN` env var needed.
+Uses `curl` for all API calls. Accepts `GITHUB_TOKEN` env var or an active `gh` auth session (token auto-resolved at lib source time) for authentication. Accepts `-r OWNER/REPO`, `-b BRANCH`, and `-o FILE` flags. Outputs a CSV with two record types: `permission` (all users/teams) and `bypass_actor` (explicit PR approval bypass entries). Reports both branch protection rules and repository rulesets.
 
 ### `github-copilot-report`
 
-Uses `gh` CLI (not `curl`/`GITHUB_TOKEN`) for all GitHub API calls; requires `gh auth refresh --scopes "read:enterprise,manage_billing:enterprise"`. Also requires `az` to be **installed** (not just logged in) — the script calls `require_command az` unconditionally before checking `--no-entra`. When `az` is logged in, enriches each user with Entra ID department and job title via `az rest`.
+Uses `curl` for all GitHub API calls. Accepts `GITHUB_TOKEN` env var (PAT with `read:enterprise` and `manage_billing:enterprise` scopes) or an active `gh` auth session (token auto-resolved at lib source time) for authentication. Also requires `az` to be **installed** when Entra ID enrichment is needed — `az` is checked at runtime only if `--no-entra` is not set and `az` is not already skipped. If `az` is not installed or not logged in, Entra lookup is silently skipped. When `az` is logged in, enriches each user with Entra ID department and job title via `az rest`.
 
 Auto-detects credits per seat from a promo/standard table keyed on plan type and today's date (promo period Jun 1 – Sep 1, 2026); override with `--credits N` or `$CREDITS_PER_SEAT_OVERRIDE`. Credits are pooled enterprise-wide, not per-user buckets. Code completions are not billed in AI credits.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ github-api-scripts/
 | bash 4+ | All scripts |
 | curl | GitHub REST and GraphQL API calls |
 | jq | JSON parsing and transformation |
-| gh CLI | Used in `github-organize-stars` and `github-repo-permissions-report` |
+| gh CLI | Used in `github-organize-stars` |
 | base64 | Used in `github-auto-repo-creation` for CODEOWNERS encoding |
 | git | Used in `github-import-repo` for bare clone + mirror push |
 | shellcheck | Linting (pre-commit hook + CI) |
@@ -142,9 +142,11 @@ Always use `SCRIPT_DIR` to build the path to `lib/github-common.sh`. The library
 | `print_status` / `print_success` / `print_warning` / `print_error` | Colored output |
 | `require_env_var <VAR>` | Exit with message if variable unset/empty |
 | `require_command <cmd>` | Exit if binary not in PATH |
+| `configure_gh_auth [scope_hint]` | Bridge GITHUB_TOKEN→GH_TOKEN or verify gh auth session |
 | `validate_github_token [bearer]` | Verify GITHUB_TOKEN via /user endpoint |
 | `validate_slug <value> <label>` | Reject values with non-alphanumeric/hyphen/underscore chars |
 | `gh_api <path> [curl args...]` | Bearer-auth REST helper with 5-retry rate-limit handling |
+| `gh_api_paginate <path> [filter] [version]` | Paginated REST helper, follows Link headers, streams items |
 | `get_enterprise_orgs` | Three-tier enterprise org resolver (REST → GraphQL → /user/orgs) |
 | `get_repo_page_count <url>` | Returns total pages for a paginated endpoint |
 
@@ -154,6 +156,8 @@ Always use `SCRIPT_DIR` to build the path to `lib/github-common.sh`. The library
 2. `validate_github_token` (or `validate_token` for secondary tokens)
 3. Validate additional inputs with `validate_slug` where needed
 4. Proceed with main logic
+
+> **Note on token auto-resolution:** Sourcing `lib/github-common.sh` automatically populates `GITHUB_TOKEN` from an active `gh` auth session if the variable is unset. This means `require_env_var GITHUB_TOKEN` may pass even when no explicit token was provided by the caller — the token was silently resolved from `gh auth token`. Script headers should document `GITHUB_TOKEN` as "Required (or provided by an active gh auth session)". Scripts that use the `gh` CLI instead of `curl` should call `configure_gh_auth` instead of step 2 above.
 
 ### Pagination (REST)
 

--- a/README.md
+++ b/README.md
@@ -516,11 +516,12 @@ cd reporting/github-monthly-issues-report
 Exports repository user/team permissions to CSV and identifies who can bypass pull request approval requirements, from both branch protection rules and repository rulesets.
 
 **Prerequisites:**
-- **[gh](https://cli.github.com)** — GitHub CLI (authenticated via `gh auth login`)
+- **[curl](https://curl.se)** — HTTP client
 - **[jq](https://stedolan.github.io/jq)** — JSON processor
 
 **Usage:**
 ```bash
+export GITHUB_TOKEN=ghp_yourtoken   # or resolved automatically from an active gh auth session
 cd reporting/github-repo-permissions-report
 ./github-repo-permissions-report.sh -r OWNER/REPO
 ./github-repo-permissions-report.sh -r OWNER/REPO -b main -o report.csv
@@ -540,9 +541,6 @@ cd reporting/github-repo-permissions-report
 - Identifies every principal that can bypass PR approval requirements
 - Produces a CSV with two record types: `permission` (all users/teams) and `bypass_actor` (explicit bypass entries)
 
-> [!NOTE]
-> Uses the `gh` CLI for all API calls. Authenticate via `gh auth login` before running.
-
 ---
 
 ### Copilot Enterprise Report
@@ -552,13 +550,17 @@ cd reporting/github-repo-permissions-report
 Generates a GitHub Copilot Enterprise licence and usage report. Shows every licensed user, their plan type, pool credit contribution, and actual AI credit consumption for the current billing month. Optionally enriches data with Entra ID department information.
 
 **Prerequisites:**
-- **[gh](https://cli.github.com)** — GitHub CLI authenticated with `read:enterprise` and `manage_billing:enterprise` scopes
-- **[az](https://learn.microsoft.com/en-us/cli/azure/)** — Azure CLI (must be installed; login required only for Entra ID department enrichment — pass `--no-entra` to skip the login requirement)
+- **[curl](https://curl.se)** — HTTP client
+- **[az](https://learn.microsoft.com/en-us/cli/azure/)** — Azure CLI (optional; required only for Entra ID department enrichment — pass `--no-entra` or omit az to skip)
 - **[jq](https://stedolan.github.io/jq)** — JSON processor
 
 **Required variables:**
 ```bash
 export GITHUB_ENTERPRISE="your-enterprise-slug"
+
+# GitHub auth — use one of:
+export GITHUB_TOKEN=ghp_yourtoken    # PAT with read:enterprise and manage_billing:enterprise scopes
+# OR: token is resolved automatically from an active gh auth session with the required scopes
 
 # Optional: Entra ID UPN domain for users without a public GitHub email
 export UPN_DOMAIN="example.com"        # e.g. 'john_example' → john@example.com
@@ -571,9 +573,7 @@ export CREDITS_PER_SEAT_OVERRIDE="1900"
 ```bash
 cd reporting/github-copilot-report
 
-# Authenticate first
-gh auth refresh --scopes "read:enterprise,manage_billing:enterprise"
-az login   # required to be installed; login needed only for department enrichment
+az login   # optional; needed only for Entra ID department enrichment
 
 ./github-copilot-report.sh -e YOUR-ENTERPRISE
 ./github-copilot-report.sh -e YOUR-ENTERPRISE -d example.com
@@ -599,10 +599,10 @@ az login   # required to be installed; login needed only for department enrichme
 - Outputs a CSV and a formatted console summary with department breakdown and model usage tables
 
 > [!IMPORTANT]
-> Requires an enterprise owner or billing manager token. Run `gh auth refresh --scopes "read:enterprise,manage_billing:enterprise"` before executing.
+> Requires a PAT with `read:enterprise` and `manage_billing:enterprise` scopes — the built-in `GITHUB_TOKEN` cannot grant enterprise-level access. Set `GITHUB_TOKEN` before executing (or have an active `gh` auth session with those scopes so the lib can auto-resolve the token).
 
 > [!NOTE]
-> Uses the `gh` CLI and (optionally) the `az` CLI. The Entra ID enrichment is skipped automatically if `az` is not logged in, or can be disabled with `--no-entra`.
+> The Entra ID enrichment is skipped automatically if `az` is not logged in, or can be disabled with `--no-entra`.
 
 ---
 
@@ -802,7 +802,7 @@ cd enterprise/github-get-public-repos
 Fetches all your starred repositories and organizes them into GitHub Lists using customizable categorization rules.
 
 **Prerequisites:**
-- **[gh](https://cli.github.com)** - GitHub CLI (authenticated via `gh auth login`)
+- **[gh](https://cli.github.com)** - GitHub CLI (authenticated via `GITHUB_TOKEN` env var or `gh auth login`)
 - **[jq](https://stedolan.github.io/jq)** - Command-line JSON processor
 
 **Usage:**
@@ -835,7 +835,7 @@ Edit the `RULES` array in the script. Each rule is a `|`-delimited string:
 The **first matching rule wins**, so order matters. Place more specific rules (e.g., AI) before general ones (e.g., Security).
 
 > [!NOTE]
-> This script uses the `gh` CLI for all API calls (GraphQL) rather than `curl`. Ensure you are authenticated via `gh auth login` before running.
+> This script uses the `gh` CLI for all API calls (GraphQL) rather than `curl`. Authenticate by setting `GITHUB_TOKEN` or by running `gh auth login`.
 
 ## Shared Library: `lib/github-common.sh`
 
@@ -921,6 +921,8 @@ Each script is published as a **composite action**, so you can reference it dire
 | `org-admin/github-migrate-internal-repos-to-private` | Convert all internal-visibility repositories to private |
 | `org-admin/github-repo-from-template` | Create a repository from a template with team permissions and a CI/CD collaborator |
 | `reporting/github-monthly-issues-report` | Generate an HTML report of issues created within a date range |
+| `reporting/github-repo-permissions-report` | Export repository collaborator/team permissions and branch-approval bypass actors to CSV |
+| `reporting/github-copilot-report` | GitHub Copilot Enterprise licence and AI credit usage report, optionally enriched with Entra ID department data |
 
 ---
 

--- a/enterprise/github-add-enterprise-team-read-permissions/action.yml
+++ b/enterprise/github-add-enterprise-team-read-permissions/action.yml
@@ -3,7 +3,7 @@ description: 'Grant read permissions to an enterprise team across all organizati
 inputs:
   github-token:
     description: 'PAT with admin:enterprise scope'
-    required: true
+    required: false
   enterprise:
     description: 'GitHub Enterprise slug'
     required: true
@@ -24,7 +24,7 @@ runs:
     - name: Add enterprise team read permissions
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ENTERPRISE: ${{ inputs.enterprise }}
         ENTERPRISE_TEAM_SLUG: ${{ inputs.enterprise-team-slug }}
         ALL_REPO_READ_ROLE_NAME: ${{ inputs.all-repo-read-role-name }}

--- a/enterprise/github-dockerfile-discovery/action.yml
+++ b/enterprise/github-dockerfile-discovery/action.yml
@@ -3,7 +3,7 @@ description: 'Discover Dockerfiles and extract FROM instructions across all ente
 inputs:
   github-token:
     description: 'PAT with read:org and repo scope'
-    required: true
+    required: false
   enterprise:
     description: 'GitHub Enterprise slug'
     required: true
@@ -41,7 +41,7 @@ runs:
     - name: Discover Dockerfiles across enterprise
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ENTERPRISE: ${{ inputs.enterprise }}
         REPORT_DIR: ${{ inputs.report-dir }}
         ORGS: ${{ inputs.orgs }}

--- a/enterprise/github-get-consumed-licenses/action.yml
+++ b/enterprise/github-get-consumed-licenses/action.yml
@@ -3,7 +3,7 @@ description: 'Report GitHub Enterprise consumed licence seat counts'
 inputs:
   github-token:
     description: 'PAT with manage_billing:enterprise scope'
-    required: true
+    required: false
   enterprise:
     description: 'GitHub Enterprise slug'
     required: true
@@ -17,7 +17,7 @@ runs:
     - name: Get consumed licenses
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ENTERPRISE: ${{ inputs.enterprise }}
         API_URL_PREFIX: ${{ inputs.api-url-prefix }}
       run: ${{ github.action_path }}/github-get-consumed-licenses.sh

--- a/enterprise/github-get-public-repos/action.yml
+++ b/enterprise/github-get-public-repos/action.yml
@@ -3,7 +3,7 @@ description: 'List all public repositories across all organizations in a GitHub 
 inputs:
   github-token:
     description: 'PAT with read:org and repo scope'
-    required: true
+    required: false
   enterprise:
     description: 'GitHub Enterprise slug'
     required: true
@@ -33,7 +33,7 @@ runs:
     - name: Get public repositories
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ENTERPRISE: ${{ inputs.enterprise }}
         REPORT_DIR: ${{ inputs.report-dir }}
         ORGS: ${{ inputs.orgs }}

--- a/lib/github-common.sh
+++ b/lib/github-common.sh
@@ -14,10 +14,17 @@
 #   print_status / print_success / print_warning / print_error
 #   require_env_var <VAR> [description]  — exit if variable is unset/empty
 #   require_command <cmd>                — exit if command not found
+#   configure_gh_auth [scope_hint]       — bridge GITHUB_TOKEN→GH_TOKEN or verify gh session
 #   validate_github_token [bearer]       — verify token via /user endpoint
+#
+# Token auto-resolution (at source time):
+#   If GITHUB_TOKEN is unset and gh CLI is available, the token is automatically
+#   resolved from the active gh auth session so curl-based scripts work with
+#   either a GITHUB_TOKEN env var or a gh CLI session.
 #   validate_token <VAR_NAME>            — verify a secondary token variable
 #   validate_slug <value> [label]        — exit if value contains unsafe chars
 #   gh_api <path|url> [curl args...]     — Bearer-auth REST helper with retry
+#   gh_api_paginate <path> [filter] [version] — paginated REST, follows Link headers
 #   _paginate_orgs_endpoint <filter> <url_tpl>  — page through an org list
 #   _graphql_enterprise_orgs             — GraphQL cursor-based enterprise orgs
 #   get_enterprise_orgs                  — three-tier enterprise org resolver
@@ -64,6 +71,29 @@ require_command() {
   local hint="${2:-${cmd}}"
   if ! command -v "${cmd}" > /dev/null 2>&1; then
     print_error "${cmd} is not installed. Please install ${hint} and try again"
+    exit 1
+  fi
+}
+
+###
+## configure_gh_auth [scope_hint]
+## Bridges GITHUB_TOKEN into the gh CLI so scripts can accept either a token
+## or an active gh auth session interchangeably.
+##
+## When GITHUB_TOKEN is set: exports it as GH_TOKEN (gh CLI reads this env var).
+## When GITHUB_TOKEN is not set: verifies gh auth status and exits with an error
+## if no session is active. scope_hint is appended to the error message.
+##
+## Usage:
+##   configure_gh_auth "gh auth login"
+##   configure_gh_auth 'gh auth refresh --scopes "read:enterprise,manage_billing:enterprise"'
+###
+configure_gh_auth() {
+  local scope_hint="${1:-gh auth login}"
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    export GH_TOKEN="$GITHUB_TOKEN"
+  elif ! gh auth status >/dev/null 2>&1; then
+    print_error "Not authenticated. Set GITHUB_TOKEN or run: ${scope_hint}"
     exit 1
   fi
 }
@@ -172,6 +202,73 @@ gh_api() {
 
   print_error "Failed to reach ${url} after 5 attempts"
   return 1
+}
+
+###
+## gh_api_paginate <path_or_url> [jq_filter] [api_version]
+## Paginated GitHub REST API helper using Link-header following.
+## Outputs each page's items (filtered by jq_filter) to stdout, one item per
+## line. Pipe the output to: jq -s '.'       to get a JSON array of all items.
+##                           jq -s '. // []' to get [] when the endpoint 404s.
+## jq_filter defaults to .[] (one item per array element).
+## api_version defaults to 2022-11-28.
+## Returns 0 silently on 404/422 (empty output); returns 1 after 5 failed attempts.
+###
+gh_api_paginate() {
+  local url="$1"
+  local jq_filter="${2:-.[]}"
+  local api_version="${3:-2022-11-28}"
+  [[ "${url}" == http* ]] || url="${API_URL_PREFIX}${url}"
+
+  local _tmp_headers _tmp_body _http_code _attempt _next_url
+  _tmp_headers=$(mktemp)
+  _tmp_body=$(mktemp)
+
+  while [[ -n "${url}" ]]; do
+    _http_code=""
+    for _attempt in 1 2 3 4 5; do
+      _http_code=$(curl -s \
+        -D "${_tmp_headers}" \
+        -o "${_tmp_body}" \
+        -w "%{http_code}" \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: ${api_version}" \
+        "${url}")
+      case "${_http_code}" in
+        200) break ;;
+        404|422)
+          rm -f "${_tmp_headers}" "${_tmp_body}"
+          return 0
+          ;;
+        403|429)
+          print_warning "Rate limited (HTTP ${_http_code}). Sleeping 60s before retry ${_attempt}/5..."
+          sleep 60
+          ;;
+        *)
+          print_warning "HTTP ${_http_code} for ${url} (attempt ${_attempt}/5)"
+          sleep 5
+          ;;
+      esac
+    done
+
+    if [[ "${_http_code}" != "200" ]]; then
+      rm -f "${_tmp_headers}" "${_tmp_body}"
+      print_error "Failed to fetch ${url} after 5 attempts"
+      return 1
+    fi
+
+    jq -rc "${jq_filter}" "${_tmp_body}" 2>/dev/null || true
+
+    # Follow Link: <next-url>; rel="next" to the next page
+    _next_url=$(grep -i "^link:" "${_tmp_headers}" \
+      | grep -o '<[^>]*>; rel="next"' \
+      | sed 's/<\([^>]*\)>.*/\1/' \
+      || true)
+    url="${_next_url}"
+  done
+
+  rm -f "${_tmp_headers}" "${_tmp_body}"
 }
 
 ###
@@ -293,3 +390,21 @@ get_enterprise_orgs() {
     '.[].login' \
     "/user/orgs?per_page=100&page=PAGE"
 }
+
+###
+## Token auto-resolution (runs once at source time)
+## If GITHUB_TOKEN is not set, attempt to derive it from an active gh CLI
+## auth session. This allows scripts that use GITHUB_TOKEN with curl to work
+## with gh CLI auth as an alternative to an explicit token.
+## Scripts should still call require_env_var GITHUB_TOKEN or
+## validate_github_token to fail fast with a clear message if neither source
+## provides a token.
+###
+if [[ -z "${GITHUB_TOKEN:-}" ]] && command -v gh &>/dev/null; then
+  _gh_resolved_token=$(gh auth token 2>/dev/null) || true
+  if [[ -n "${_gh_resolved_token:-}" ]]; then
+    GITHUB_TOKEN="$_gh_resolved_token"
+    export GITHUB_TOKEN
+  fi
+  unset _gh_resolved_token
+fi

--- a/org-admin/github-add-repo-collaborators-by-pattern/action.yml
+++ b/org-admin/github-add-repo-collaborators-by-pattern/action.yml
@@ -3,7 +3,7 @@ description: 'Add individual collaborators to repositories whose names match a r
 inputs:
   github-token:
     description: 'PAT with repo and admin:org scope'
-    required: true
+    required: false
   org:
     description: 'GitHub organization name'
     required: true
@@ -31,7 +31,7 @@ runs:
     - name: Add collaborators to matching repositories
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ORG: ${{ inputs.org }}
         COLLABORATORS: ${{ inputs.collaborators }}
         REPO_NAME_REGEX: ${{ inputs.repo-name-regex }}

--- a/org-admin/github-add-repo-permissions/action.yml
+++ b/org-admin/github-add-repo-permissions/action.yml
@@ -3,7 +3,7 @@ description: 'Grant team permissions across all repositories in a GitHub organiz
 inputs:
   github-token:
     description: 'PAT with admin:org scope'
-    required: true
+    required: false
   org:
     description: 'GitHub organization name'
     required: true
@@ -41,7 +41,7 @@ runs:
     - name: Grant team permissions to repositories
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ORG: ${{ inputs.org }}
         REPO_NAME_FILTER: ${{ inputs.repo-name-filter }}
         REPO_ADMIN: ${{ inputs.repo-admin }}

--- a/org-admin/github-archive-old-repos/action.yml
+++ b/org-admin/github-archive-old-repos/action.yml
@@ -3,7 +3,7 @@ description: 'Archive repositories that have not been updated within a configura
 inputs:
   github-token:
     description: 'PAT with repo scope'
-    required: true
+    required: false
   org:
     description: 'GitHub organization name'
     required: true
@@ -29,7 +29,7 @@ runs:
     - name: Archive old repositories
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ORG: ${{ inputs.org }}
         YEARS_THRESHOLD: ${{ inputs.years-threshold }}
         REPORT_DIR: ${{ inputs.report-dir }}

--- a/org-admin/github-auto-repo-creation/action.yml
+++ b/org-admin/github-auto-repo-creation/action.yml
@@ -3,7 +3,7 @@ description: 'Create private repositories with branch protection, CODEOWNERS, an
 inputs:
   github-token:
     description: 'PAT with repo and admin:org scope'
-    required: true
+    required: false
   org:
     description: 'GitHub organization name'
     required: true
@@ -27,7 +27,7 @@ runs:
     - name: Create repositories
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ORG: ${{ inputs.org }}
         REPO_NAMES: ${{ inputs.repo-names }}
         REPO_OWNERS: ${{ inputs.repo-owners }}

--- a/org-admin/github-close-archived-repo-security-alerts/action.yml
+++ b/org-admin/github-close-archived-repo-security-alerts/action.yml
@@ -3,7 +3,7 @@ description: 'Dismiss all open Dependabot, code-scanning, and secret-scanning al
 inputs:
   github-token:
     description: 'PAT with security_events and repo scope'
-    required: true
+    required: false
   org:
     description: 'GitHub organization name'
     required: true
@@ -37,7 +37,7 @@ runs:
     - name: Close archived repo security alerts
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ORG: ${{ inputs.org }}
         DEPENDABOT_REASON: ${{ inputs.dependabot-reason }}
         CODE_SCANNING_REASON: ${{ inputs.code-scanning-reason }}

--- a/org-admin/github-enable-issues/action.yml
+++ b/org-admin/github-enable-issues/action.yml
@@ -3,7 +3,7 @@ description: 'Enable the Issues feature on all repositories where it is currentl
 inputs:
   github-token:
     description: 'PAT with repo or admin:org scope'
-    required: true
+    required: false
   org:
     description: 'GitHub organization name'
     required: true
@@ -21,7 +21,7 @@ runs:
     - name: Enable Issues on repositories
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ORG: ${{ inputs.org }}
         API_URL_PREFIX: ${{ inputs.api-url-prefix }}
       run: |

--- a/org-admin/github-get-repo-list/action.yml
+++ b/org-admin/github-get-repo-list/action.yml
@@ -3,7 +3,7 @@ description: 'Output a CSV list of all repositories in a GitHub organization to 
 inputs:
   github-token:
     description: 'PAT with read:org and repo scope'
-    required: true
+    required: false
   org:
     description: 'GitHub organization name'
     required: true
@@ -17,7 +17,7 @@ runs:
     - name: Get repository list
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ORG: ${{ inputs.org }}
         API_URL_PREFIX: ${{ inputs.api-url-prefix }}
       run: ${{ github.action_path }}/github-get-repo-list.sh

--- a/org-admin/github-import-repo/action.yml
+++ b/org-admin/github-import-repo/action.yml
@@ -3,7 +3,7 @@ description: 'Mirror-clone a repository and push it to a new private repository 
 inputs:
   github-token:
     description: 'PAT with repo scope'
-    required: true
+    required: false
   org:
     description: 'GitHub organization name'
     required: true
@@ -30,7 +30,7 @@ runs:
     - name: Import repository
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ORG: ${{ inputs.org }}
         OWNER_USERNAME: ${{ inputs.owner-username }}
         API_URL_PREFIX: ${{ inputs.api-url-prefix }}

--- a/org-admin/github-migrate-internal-repos-to-private/action.yml
+++ b/org-admin/github-migrate-internal-repos-to-private/action.yml
@@ -3,7 +3,7 @@ description: 'Convert all internal-visibility repositories in an organization to
 inputs:
   github-token:
     description: 'PAT with repo scope'
-    required: true
+    required: false
   org:
     description: 'GitHub organization name'
     required: true
@@ -17,7 +17,7 @@ runs:
     - name: Migrate internal repos to private
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ORG: ${{ inputs.org }}
         API_URL_PREFIX: ${{ inputs.api-url-prefix }}
       run: ${{ github.action_path }}/github-migrate-internal-repos-to-private.sh

--- a/org-admin/github-repo-from-template/action.yml
+++ b/org-admin/github-repo-from-template/action.yml
@@ -3,7 +3,7 @@ description: 'Create a private repository from a template with team permissions 
 inputs:
   github-token:
     description: 'PAT with repo scope'
-    required: true
+    required: false
   org:
     description: 'GitHub organization name'
     required: true
@@ -37,7 +37,7 @@ runs:
     - name: Create repository from template
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ORG: ${{ inputs.org }}
         TEMPLATE_REPO: ${{ inputs.template-repo }}
         CD_USERNAME: ${{ inputs.cd-username }}

--- a/personal/github-organize-stars/github-organize-stars.sh
+++ b/personal/github-organize-stars/github-organize-stars.sh
@@ -14,15 +14,21 @@
 #   ./github-organize-stars.sh --no-cache   # Force re-fetch stars from GitHub
 #
 # Environment variables:
-#   CACHE_FILE  Optional. Path to the stars cache file
+#   GITHUB_TOKEN  Optional. PAT or token used to authenticate gh CLI.
+#                 When set, takes precedence over any active gh auth session.
+#   CACHE_FILE    Optional. Path to the stars cache file
 #               (default: ~/.cache/gh-star-organizer/stars.json)
 #
 # Requirements:
-#   - gh (GitHub CLI, authenticated)
+#   - gh (GitHub CLI, authenticated via GITHUB_TOKEN or gh auth login)
 #   - jq
 # =============================================================================
 
 set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../lib/github-common.sh
+source "${SCRIPT_DIR}/../../lib/github-common.sh"
 
 # ---- Dependency check -------------------------------------------------------
 for cmd in gh jq; do
@@ -54,6 +60,8 @@ for arg in "$@"; do
     *) echo "Unknown argument: $arg  (use --help)" >&2; exit 1 ;;
   esac
 done
+
+configure_gh_auth "gh auth login"
 
 # =============================================================================
 # CATEGORY RULES

--- a/reporting/github-copilot-report/action.yml
+++ b/reporting/github-copilot-report/action.yml
@@ -1,0 +1,40 @@
+name: 'Copilot Report'
+description: 'GitHub Copilot Enterprise licence and AI credit usage report, optionally enriched with Entra ID department data'
+inputs:
+  github-token:
+    description: 'PAT with read:enterprise and manage_billing:enterprise scopes. Cannot be the built-in GITHUB_TOKEN.'
+    required: true
+  enterprise:
+    description: 'GitHub Enterprise slug'
+    required: true
+  upn-domain:
+    description: 'Email domain for Entra ID lookup when GitHub carries no email address (e.g. example.com)'
+    required: false
+    default: ''
+  credits:
+    description: 'Override credits-per-seat value if your portal shows a different pool size'
+    required: false
+    default: ''
+  output:
+    description: 'Output CSV file path (default: copilot-report-YYYYMMDD.csv)'
+    required: false
+    default: ''
+  no-entra:
+    description: 'Skip Entra ID department lookup'
+    required: false
+    default: 'false'
+runs:
+  using: composite
+  steps:
+    - name: Generate Copilot report
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_ENTERPRISE: ${{ inputs.enterprise }}
+        UPN_DOMAIN: ${{ inputs.upn-domain }}
+        CREDITS_PER_SEAT_OVERRIDE: ${{ inputs.credits }}
+      run: |
+        ARGS=()
+        [[ -n "${{ inputs.output }}" ]]   && ARGS+=(--output "${{ inputs.output }}")
+        [[ "${{ inputs.no-entra }}" == "true" ]] && ARGS+=(--no-entra)
+        "${{ github.action_path }}/github-copilot-report.sh" "${ARGS[@]}"

--- a/reporting/github-copilot-report/github-copilot-report.sh
+++ b/reporting/github-copilot-report/github-copilot-report.sh
@@ -5,10 +5,14 @@
 # GitHub Copilot Enterprise licence & usage report, optionally enriched with
 # Entra ID department data. Output: CSV file + console summary.
 #
-# Authentication — no tokens or secrets required in flags:
-#   GitHub : gh CLI  (run 'gh auth refresh --scopes "read:enterprise,manage_billing:enterprise"'
-#                     as enterprise owner or billing manager)
-#   Entra  : az CLI  (run 'az login' once; needs User.Read.All)
+# Authentication — no secrets required in flags:
+#   GitHub : GITHUB_TOKEN env var  (PAT with read:enterprise and
+#                                   manage_billing:enterprise scopes)
+#            OR provided automatically from an active gh auth session
+#            with the required scopes
+#   Entra  : az CLI  (optional; run 'az login' once; needs User.Read.All)
+#            Skipped automatically if az is not installed or not logged in.
+#            Use --no-entra to suppress Entra lookups explicitly.
 #
 # What this reports:
 #   • Every user with a Copilot seat, their plan type, and their pool contribution
@@ -36,6 +40,8 @@ source "${SCRIPT_DIR}/../../lib/github-common.sh"
 
 # ── Defaults ──────────────────────────────────────────────────────────────────
 GITHUB_ENTERPRISE="${GITHUB_ENTERPRISE:-}"
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+API_URL_PREFIX="${API_URL_PREFIX:-https://api.github.com}"
 UPN_DOMAIN="${UPN_DOMAIN:-}"
 CREDITS_PER_SEAT_OVERRIDE="${CREDITS_PER_SEAT_OVERRIDE:-}"
 OUTPUT_CSV="copilot-report-$(date +%Y%m%d).csv"
@@ -109,8 +115,9 @@ Usage: github-copilot-report.sh [OPTIONS]
 GitHub Copilot Enterprise licence + usage report, optionally enriched with
 Entra ID department information.
 
-Authentication (no secrets in flags — both CLIs handle auth):
-  GitHub  →  gh auth refresh --scopes "read:enterprise,manage_billing:enterprise"
+Authentication (no secrets in flags):
+  GitHub  →  export GITHUB_TOKEN=ghp_yourtoken  (read:enterprise,manage_billing:enterprise)
+             OR resolved automatically from an active gh auth session
   Entra   →  az login
 
 Options:
@@ -124,7 +131,7 @@ Options:
       --no-entra         Skip Entra ID department lookup
   -h, --help             Show this message
 
-Required gh CLI scopes:
+Required GITHUB_TOKEN scopes:
   read:enterprise
   manage_billing:enterprise          (requires enterprise owner or billing manager)
 
@@ -150,15 +157,17 @@ done
 [[ -z "$GITHUB_ENTERPRISE" ]] && \
     err "GitHub Enterprise slug is required  (-e / \$GITHUB_ENTERPRISE)"
 
-require_command gh
-require_command az
 require_command jq
 
-gh auth status &>/dev/null || err "gh CLI is not authenticated. Run: gh auth refresh --scopes \"read:enterprise,manage_billing:enterprise\""
+require_env_var GITHUB_TOKEN
+validate_github_token "bearer"
 
 # ── Acquire Microsoft Graph token via az CLI ──────────────────────────────────
 if [[ "$NO_ENTRA" == "true" ]]; then
     warn "Entra ID lookup disabled (--no-entra). Department column will be N/A."
+elif ! command -v az &>/dev/null; then
+    warn "az CLI is not installed — department/division grouping will be skipped."
+    warn "Install the Azure CLI and run 'az login' to enable Entra ID enrichment, or pass --no-entra."
 elif az account show &>/dev/null 2>&1; then
     info "Acquiring Microsoft Graph token via az CLI..."
     GRAPH_TOKEN=$(az account get-access-token \
@@ -176,14 +185,36 @@ else
     warn "Run 'az login' to enable Entra ID enrichment, or pass --no-entra."
 fi
 
-# ── GitHub API via gh CLI ─────────────────────────────────────────────────────
-# Thin wrapper that injects the standard Accept and version headers.
-# Pass any extra 'gh api' flags (e.g. --paginate, --jq, --input) as arguments.
-gh_api() {
-    gh api \
-        -H "Accept: application/vnd.github+json" \
-        -H "X-GitHub-Api-Version: 2026-03-10" \
-        "$@"
+# ── GitHub API via curl with Copilot API version ──────────────────────────────
+# The Copilot usage-metrics endpoints require API version 2026-03-10.
+# Uses the same retry/rate-limit logic as lib's gh_api.
+_copilot_api() {
+    local url="$1"
+    shift
+    [[ "${url}" == http* ]] || url="${API_URL_PREFIX:-https://api.github.com}${url}"
+
+    local _attempt _http_code _body
+    for _attempt in 1 2 3 4 5; do
+        _body=$(curl -s -w "\n%{http_code}" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            "$@" "${url}")
+        _http_code=$(echo "${_body}" | tail -1)
+        _body=$(echo "${_body}" | head -n -1)
+        case "${_http_code}" in
+            200) echo "${_body}"; return 0 ;;
+            404) echo "__404__";  return 0 ;;
+            422) echo "__422__";  return 0 ;;
+            403|429)
+                warn "Rate limited (HTTP ${_http_code}). Sleeping 60s before retry ${_attempt}/5..."
+                sleep 60 ;;
+            *)
+                warn "HTTP ${_http_code} from GitHub API (attempt ${_attempt}/5)"
+                sleep 5 ;;
+        esac
+    done
+    err "Failed to reach ${url} after 5 attempts"
 }
 
 # fetch_usage_ndjson REPORT_PATH
@@ -193,7 +224,8 @@ gh_api() {
 fetch_usage_ndjson() {
     local path="$1"
     local resp links
-    resp=$(gh_api "${path}" 2>/dev/null) || return 0
+    resp=$(_copilot_api "${path}" 2>/dev/null) || return 0
+    [[ "${resp}" == "__404__" || "${resp}" == "__422__" ]] && return 0
     links=$(echo "$resp" | jq -r '.download_links[]? // empty' 2>/dev/null) || return 0
     [[ -z "$links" ]] && return 0
     while IFS= read -r url; do
@@ -208,9 +240,7 @@ TOTAL_ASSIGNED_SEATS=0
 
 fetch_seats() {
     local slug="$1"
-    gh_api --paginate \
-        --jq '.seats[]' \
-        "/enterprises/${slug}/copilot/billing/seats" \
+    gh_api_paginate "/enterprises/${slug}/copilot/billing/seats" '.seats[]' '2026-03-10' \
     | jq -s '.'
 }
 
@@ -294,10 +324,10 @@ while IFS= read -r _login; do
     [[ -z "$_login" ]] && continue
     _login_i=$(( _login_i + 1 ))
     printf '\r  [%d/%d] %s          ' "$_login_i" "$_LOGIN_COUNT" "$_login" >&2
-    _resp=$(gh_api \
+    _resp=$(_copilot_api \
         "/enterprises/${GITHUB_ENTERPRISE}/settings/billing/ai_credit/usage?user=${_login}&year=${_BILLING_YEAR}&month=${_BILLING_MONTH}" \
         2>/dev/null) || _resp=""
-    if [[ -n "$_resp" ]]; then
+    if [[ -n "$_resp" && "${_resp}" != "__404__" && "${_resp}" != "__422__" ]]; then
         _credits=$(echo "$_resp" | jq '[.usageItems[]?.grossQuantity // 0] | add // 0 | round' 2>/dev/null || echo "0")
         # Store per-model breakdown
         while IFS=$'\t' read -r _model _qty; do
@@ -317,7 +347,7 @@ if [[ "$_billing_ok" == "true" ]]; then
     info "Loaded billing data for ${#USER_CREDITS_USED[@]} user(s)."
 else
     warn "Some billing API calls failed — credits may show 0 for affected users."
-    warn "Ensure manage_billing:enterprise scope: gh auth refresh --scopes \"read:enterprise,manage_billing:enterprise\""
+    warn "Ensure manage_billing:enterprise scope: set GITHUB_TOKEN with the required scopes"
 fi
 
 # Build sorted list of all model names seen across all users

--- a/reporting/github-monthly-issues-report/action.yml
+++ b/reporting/github-monthly-issues-report/action.yml
@@ -3,7 +3,7 @@ description: 'Generate an HTML report of issues created within a date range'
 inputs:
   github-token:
     description: 'PAT with repo scope'
-    required: true
+    required: false
   org:
     description: 'GitHub organization name'
     required: true
@@ -30,7 +30,7 @@ runs:
     - name: Generate monthly issues report
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
         ORG: ${{ inputs.org }}
         REPO: ${{ inputs.repo }}
         MONTH_START: ${{ inputs.month-start }}

--- a/reporting/github-repo-permissions-report/action.yml
+++ b/reporting/github-repo-permissions-report/action.yml
@@ -1,0 +1,29 @@
+name: 'Repo Permissions Report'
+description: 'Export repository collaborator/team permissions and branch-approval bypass actors to CSV'
+inputs:
+  github-token:
+    description: 'GitHub token with repo and read:org scopes. Defaults to the built-in GITHUB_TOKEN.'
+    required: false
+  repo:
+    description: 'Target repository in OWNER/REPO format'
+    required: true
+  branch:
+    description: 'Branch to evaluate (default: repository default branch)'
+    required: false
+    default: ''
+  output:
+    description: 'Output CSV file path'
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+    - name: Generate repository permissions report
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token || github.token }}
+      run: |
+        ARGS=(-r "${{ inputs.repo }}")
+        [[ -n "${{ inputs.branch }}" ]] && ARGS+=(-b "${{ inputs.branch }}")
+        [[ -n "${{ inputs.output }}" ]] && ARGS+=(-o "${{ inputs.output }}")
+        "${{ github.action_path }}/github-repo-permissions-report.sh" "${ARGS[@]}"

--- a/reporting/github-repo-permissions-report/github-repo-permissions-report.sh
+++ b/reporting/github-repo-permissions-report/github-repo-permissions-report.sh
@@ -10,8 +10,13 @@
 #   - permission    : collaborators/teams and whether they can bypass approvals
 #   - bypass_actor  : explicit bypass actors from branch protection and rulesets
 #
+# Environment variables:
+#   GITHUB_TOKEN    Required. PAT with repo and read:org scope
+#                   (or provided automatically from an active gh auth session)
+#   API_URL_PREFIX  Optional. GitHub API base URL (default: https://api.github.com)
+#
 # Requirements:
-#   - gh CLI authenticated with access to the target repository
+#   - curl
 #   - jq
 # =============================================================================
 
@@ -21,7 +26,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../lib/github-common.sh
 source "${SCRIPT_DIR}/../../lib/github-common.sh"
 
-API_VERSION="2022-11-28"
+API_URL_PREFIX=${API_URL_PREFIX:-'https://api.github.com'}
 REPO=""
 BRANCH=""
 OUTPUT_CSV=""
@@ -75,10 +80,10 @@ done
 
 [[ -z "$REPO" ]] && err "Repository is required. Use -r OWNER/REPO"
 
-require_command gh
 require_command jq
 
-gh auth status >/dev/null 2>&1 || err "gh is not authenticated. Run: gh auth login"
+require_env_var GITHUB_TOKEN
+validate_github_token
 
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
@@ -90,15 +95,10 @@ BP_JSON="${TMP_DIR}/branch_protection.json"
 RULESETS_JSON="${TMP_DIR}/rulesets.json"
 BYPASS_JSON="${TMP_DIR}/bypass.json"
 
-gh_api() {
-  gh api \
-    -H "Accept: application/vnd.github+json" \
-    -H "X-GitHub-Api-Version: ${API_VERSION}" \
-    "$@"
-}
-
 info "Fetching repository metadata for ${REPO}..."
-gh_api "/repos/${REPO}" > "$REPO_JSON"
+_repo_resp=$(gh_api "/repos/${REPO}")
+[[ "${_repo_resp}" == "__404__" ]] && err "Repository ${REPO} not found or not accessible"
+echo "${_repo_resp}" > "$REPO_JSON"
 DEFAULT_BRANCH="$(jq -r '.default_branch // empty' "$REPO_JSON")"
 [[ -z "$DEFAULT_BRANCH" ]] && err "Unable to determine default branch for ${REPO}"
 
@@ -111,30 +111,24 @@ if [[ -z "$OUTPUT_CSV" ]]; then
 fi
 
 info "Fetching collaborators..."
-gh_api --paginate \
-  "/repos/${REPO}/collaborators?affiliation=all&per_page=100" \
-  --jq '.[]' | jq -s '.' > "$COLLAB_JSON"
+gh_api_paginate "/repos/${REPO}/collaborators?affiliation=all&per_page=100" '.[]' \
+  | jq -s '.' > "$COLLAB_JSON"
 
 info "Fetching teams with repository access..."
-gh_api --paginate \
-  "/repos/${REPO}/teams?per_page=100" \
-  --jq '.[]' | jq -s '.' > "$TEAMS_JSON"
+gh_api_paginate "/repos/${REPO}/teams?per_page=100" '.[]' \
+  | jq -s '.' > "$TEAMS_JSON"
 
 info "Fetching branch protection for ${BRANCH} (if configured)..."
-if gh_api "/repos/${REPO}/branches/${BRANCH}/protection" > "$BP_JSON" 2>/dev/null; then
-  :
-else
+_bp_resp=$(gh_api "/repos/${REPO}/branches/${BRANCH}/protection")
+if [[ "${_bp_resp}" == "__404__" || "${_bp_resp}" == "__422__" ]]; then
   echo '{}' > "$BP_JSON"
+else
+  echo "${_bp_resp}" > "$BP_JSON"
 fi
 
 info "Fetching repository rulesets (if configured)..."
-if gh_api --paginate \
-  "/repos/${REPO}/rulesets?includes_parents=true&per_page=100" \
-  --jq '.[]' | jq -s '.' > "$RULESETS_JSON" 2>/dev/null; then
-  :
-else
-  echo '[]' > "$RULESETS_JSON"
-fi
+gh_api_paginate "/repos/${REPO}/rulesets?includes_parents=true&per_page=100" '.[]' \
+  | jq -s '. // []' > "$RULESETS_JSON"
 
 info "Building bypass actor list (branch protection + applicable rulesets)..."
 jq -n \


### PR DESCRIPTION
## Summary

All scripts now support **both** `GITHUB_TOKEN` env var and an active `gh` CLI auth session interchangeably, and all work in GitHub Actions without extra configuration.

## Changes

### `lib/github-common.sh`
- **Auto-resolution block**: at lib source time, if `GITHUB_TOKEN` is unset and `gh` is available, the token is resolved via `gh auth token` and exported — zero changes needed in curl-based scripts
- **`configure_gh_auth()`**: bridges `GITHUB_TOKEN→GH_TOKEN` for scripts that use the `gh` CLI directly, or verifies an active `gh` session
- **`gh_api_paginate()`**: new paginated REST helper that follows `Link` headers, streams items through a `jq` filter, handles 404/422 silently, and accepts a custom API version header

### All `action.yml` files (16 existing + 2 new)
- `github-token` changed from `required: true` to `required: false`
- Env mapping uses `${{ inputs.github-token || github.token }}` so the built-in Actions token is used when no PAT is provided
- New `action.yml` added for `github-repo-permissions-report`
- New `action.yml` added for `github-copilot-report`

### Scripts converted from `gh` CLI to `curl`
- **`github-repo-permissions-report.sh`**: removed `gh` CLI dependency; uses lib's `gh_api` + `gh_api_paginate` for all calls; branch protection 404s handled via `__404__` sentinel
- **`github-copilot-report.sh`**: removed `gh` CLI dependency; added local `_copilot_api()` with API version `2026-03-10`; `fetch_seats()` uses `gh_api_paginate`; `az` CLI is now truly optional (silently skipped if not installed/logged in, even without `--no-entra`); fixed missing `API_URL_PREFIX` default that caused `validate_github_token` to always fail

### `github-organize-stars.sh` (kept as `gh`-based)
- Now sources `lib/github-common.sh` for shared helpers
- Calls `configure_gh_auth` for consistent auth handling
- Kept as `gh` CLI-based since it uses GraphQL mutations

### Documentation
- `README.md`: prerequisites, usage examples, and available actions table updated
- `AGENTS.md`: shared library table, tech stack, and error handling sequence updated
- `.github/copilot-instructions.md`: script descriptions updated to reflect new tooling

## Testing

- All modified `.sh` files pass `bash -n` syntax check
- Pre-commit secret scan passed on all commits
- Scripts should be tested against a non-production org/enterprise before production use