### PR TITLE
fix: handle __404__ sentinel in github-dockerfile-discovery

### DIFF
--- a/enterprise/github-dockerfile-discovery/github-dockerfile-discovery.sh
+++ b/enterprise/github-dockerfile-discovery/github-dockerfile-discovery.sh
@@ -136,7 +136,7 @@ search_dockerfiles_in_org() {
     local resp
     resp=$(gh_api "/search/code?q=filename:Dockerfile+org:${org}&per_page=100&page=${page}")
 
-    if [ "${resp}" = "__422__" ]; then
+    if [[ "${resp}" == "__422__" || "${resp}" == "__404__" ]]; then
       print_warning "  Code search not available for org '${org}'. Skipping."
       return 0
     fi
@@ -282,7 +282,7 @@ fetch_and_parse_dockerfile() {
 
   resp=$(gh_api "/repos/${repo_full_name}/contents/${encoded_path}" 2>/dev/null || echo "")
 
-  if [ -z "${resp}" ]; then
+  if [[ -z "${resp}" || "${resp}" == "__404__" || "${resp}" == "__422__" ]]; then
     print_warning "    Could not fetch ${repo_full_name}/${path}"
     return 0
   fi


### PR DESCRIPTION
## Summary

Two places in `github-dockerfile-discovery.sh` called lib's `gh_api` but didn't handle the `__404__` sentinel value, introduced alongside `__422__` in the dual-auth refactor.

## Changes

**`enterprise/github-dockerfile-discovery/github-dockerfile-discovery.sh`**

- `search_org_dockerfiles`: added `__404__` to the existing `__422__` guard — orgs that return 404 for code search are now skipped cleanly with a warning instead of crashing on `jq` trying to parse `__404__` as JSON
- `fetch_dockerfile_content`: added `__404__` and `__422__` to the empty-string guard — avoids a misleading `Unexpected encoding '__404__'` warning when a file path is not found

`github-get-public-repos` already handles all three cases (`__404__`, `__422__`, empty) — no change needed there.

## Root cause

The `gh_api` library helper returns string sentinels `__404__` and `__422__` instead of non-zero exit codes. Any caller that only checks for empty string or only checks for `__422__` will silently pass the sentinel to `jq`, which either errors or produces unexpected output.