### PR TITLE
fix: point release-please to VERSION file

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "version-file": "VERSION",
   "include-v-in-tag": true,
   "changelog-sections": [
     {"type": "feat",     "section": "Features"},


### PR DESCRIPTION
The `simple` release type defaults to `version.txt`; adding `version-file: "VERSION"` to `release-please-config.json` tells it to update the `VERSION` file on each release.