### PR TITLE
fix: pass version-file to release-please action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           release-type: simple
+          version-file: VERSION


### PR DESCRIPTION
The `version-file` setting in `release-please-config.json` is silently ignored when `release-type` is set in the workflow's `with:` block — the action boots a fresh config and looks for `version.txt` (the default). Passing `version-file: VERSION` directly to the action fixes this.