### PR TITLE
fix: use config-file/manifest-file so version-file is honoured

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
-          release-type: simple
-          version-file: VERSION
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
The `release-type: simple` workflow input bypasses `release-please-config.json`, causing the action to default to `version.txt` and ignore `version-file: VERSION`. Removing `release-type` and passing explicit `config-file`/`manifest-file` inputs forces the action to read all settings from the config file.