### PR TITLE
fix: add packages section to release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "simple",
-  "version-file": "VERSION",
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "version-file": "VERSION"
+    }
+  },
   "include-v-in-tag": true,
   "changelog-sections": [
     {"type": "feat",     "section": "Features"},


### PR DESCRIPTION
In manifest mode (`config-file` + `manifest-file`), release-please requires an explicit `packages` section — without it the action finds 0 release commit SHAs and creates no PR. Moving `release-type` and `version-file` under `packages["."]" fixes this and ensures `VERSION` is updated on every release.