### PR TITLE
chore: make refactor commits visible in Release Please changelog

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -267,7 +267,7 @@ All commits **must** follow [Conventional Commits](https://www.conventionalcommi
 | `docs:` | patch bump (visible) | `docs: update GitHub Actions examples in README` |
 | `chore:` | no bump (hidden) | `chore: update actions/checkout to v7` |
 | `ci:` | no bump (hidden) | `ci: pin release-please-action SHA` |
-| `refactor:` | no bump (hidden) | `refactor: extract pagination helper` |
+| `refactor:` | patch | `refactor: extract pagination helper` |
 
 ### Variable Naming Conventions
 - `GITHUB_TOKEN` — main admin token

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,7 +261,7 @@ All commits **must** follow [Conventional Commits](https://www.conventionalcommi
 | `feat!:` / `BREAKING CHANGE:` | major | ✅ |
 | `chore:` | none | hidden |
 | `ci:` | none | hidden |
-| `refactor:` | none | hidden |
+| `refactor:` | patch | Code Refactoring |
 | `test:` | none | hidden |
 
 ---

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,7 @@
     {"type": "deps",     "section": "Dependencies"},
     {"type": "chore",    "section": "Miscellaneous", "hidden": true},
     {"type": "style",    "section": "Miscellaneous", "hidden": true},
-    {"type": "refactor", "section": "Miscellaneous", "hidden": true},
+    {"type": "refactor", "section": "Code Refactoring"},
     {"type": "test",     "section": "Miscellaneous", "hidden": true},
     {"type": "build",    "section": "Miscellaneous", "hidden": true},
     {"type": "ci",       "section": "Miscellaneous", "hidden": true}


### PR DESCRIPTION
Moves `refactor:` from the hidden `Miscellaneous` section to a visible `Code Refactoring` section so internal cleanup PRs trigger a release PR and patch version bump.

```diff
-{"type": "refactor", "section": "Miscellaneous", "hidden": true},
+{"type": "refactor", "section": "Code Refactoring"},
```